### PR TITLE
qdoubleslider

### DIFF
--- a/lectures/1_image_filters.ipynb
+++ b/lectures/1_image_filters.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "tags": [
      "hide-cell"
@@ -886,37 +886,7 @@
     "import napari\n",
     "from napari.layers import Image\n",
     "from magicgui import magicgui\n",
-    "\n",
-    "\n",
-    "from qtpy import QtWidgets, QtCore\n",
-    "\n",
-    "class QDoubleSlider(QtWidgets.QSlider):\n",
-    "\n",
-    "    def __init__(self, parent=None, minimum=0, maximum=1, step=0.01, default=0):\n",
-    "        self.minimum = minimum\n",
-    "        self.maximum = maximum\n",
-    "        self.step = step\n",
-    "        super().__init__(QtCore.Qt.Horizontal, parent=parent)\n",
-    "        super().setMaximum(self.toint(maximum))\n",
-    "        super().setTickInterval(1)\n",
-    "        super().setMinimum(0)\n",
-    "        super().setValue(self.toint(default))\n",
-    "\n",
-    "    def toint(self, value):\n",
-    "        return int(np.round((value - self.minimum) / self.step))\n",
-    "    \n",
-    "    def tofloat(self, value):\n",
-    "        return value * self.step + self.minimum\n",
-    "        \n",
-    "    def value(self):\n",
-    "        return self.tofloat(super().value())\n",
-    "\n",
-    "    def setValue(self, value):\n",
-    "        super().setValue(self.toint(value))\n",
-    "\n",
-    "    def setMaximum(self, value):\n",
-    "        self.maximum = value\n",
-    "        super().setMaximum(int(np.round((self.maximum - self.minimum) / self.step)))\n",
+    "from magicgui._qt.widgets import QDoubleSlider\n",
     "\n",
     "\n",
     "def fractional_convolve_gen(image, kernel, **kwargs):\n",
@@ -1708,7 +1678,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/lectures/1_image_filters.ipynb
+++ b/lectures/1_image_filters.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "hide-cell"
@@ -1678,7 +1678,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
You might have already known this and avoided because of the private import ... but magicgui provides a QDoubleSlider that you can use if you want: `from magicgui._qt.widgets import QDoubleSlider`

feel free to ignore if you knew that...

Also, just curious, why did you do this as a `filter_interactive_demo(image, kernel)` function?  It doesn't seem like you ever call that function more than the one time, ... but is it so that they could change up the image on their own if they want?  